### PR TITLE
Move out TypeCheck and Coercible

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ isb2 = asOneOf "foo"
 The library also defines `Undefined`. Combined with `OneOf`, it can represent an optional type:
 
 ```purescript
+import Runtime.Undefined
+
 type OptionalInt = Int |+| Undefined
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,17 +85,18 @@ type Props =
   }
 ```
 
-A `urecord` helper is made available to convert records with the same runtime value:
+A `coerce` helper is made available to convert records with the same runtime value:
 
 ```purescript
+import Runtime.Coercible (coerce)
+
 sampleProps :: Props
 sampleProps =
-  urecord { text: "foo" -- text is required and should be a string
+  coerce { text: "foo" -- text is required and should be a string
 
-          , width: 30.0 -- width is optional, and may be defined, but should be a Number
-          -- height is optional and may be omitted
-
-          , fontSize: "100%" -- fontSize may be defined, and should either be a string or number
-          }
+         , width: 30.0 -- width is optional, and may be defined, but should be a Number
+         -- height is optional and may be omitted
+         , fontSize: "100%" -- fontSize may be defined, and should either be a string or number
+         }
 
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A data type for untagged unions.
 Consider a the following type:
 
 ```purescript
-import OneOf
+import Runtime.OneOf
 
 type ISB = Int |+| String |+| Boolean
 ```

--- a/spago.dhall
+++ b/spago.dhall
@@ -9,6 +9,7 @@ You can edit this file as you like.
     , "console"
     , "effect"
     , "foreign"
+    , "foreign-object"
     , "maybe"
     , "newtype"
     , "proxy"

--- a/spago.dhall
+++ b/spago.dhall
@@ -10,6 +10,7 @@ You can edit this file as you like.
     , "effect"
     , "foreign"
     , "maybe"
+    , "newtype"
     , "proxy"
     , "psci-support"
     , "tuples"

--- a/src/Runtime/Coercible.purs
+++ b/src/Runtime/Coercible.purs
@@ -1,0 +1,42 @@
+module Runtime.Coercible
+       ( class Coercible
+       , class CoercibleRecordRL
+       , coerce
+       ) where
+
+import Foreign (Foreign)
+import Prim.RowList (class RowToList, Cons, Nil, kind RowList)
+import Runtime.Undefined (Undefined)
+import Unsafe.Coerce (unsafeCoerce)
+
+--| A `Coercible a b` exists if all values of type `a` have
+--| runtime values that can be interpreted as that of type `b`.
+class Coercible a b
+
+instance coercibleIntNumber :: Coercible Int Number
+instance coercibleCharString :: Coercible Char String
+instance coercibleRecord ::
+  ( RowToList r rl
+  , RowToList r' rl'
+  , CoercibleRecordRL rl rl'
+  ) => Coercible {|r} {|r'}
+instance coercibleForeign :: Coercible x Foreign
+
+class CoercibleRecordRL (rl :: RowList) (rl' :: RowList)
+
+instance coercibleRecordRLNil :: CoercibleRecordRL Nil Nil
+else instance coercibleRecordRLConsDirect ::
+  ( CoercibleRecordRL trl trl'
+  ) => CoercibleRecordRL (Cons name typ trl) (Cons name typ trl')
+else instance coercibleRecordRLConsCoercible ::
+  ( CoercibleRecordRL trl trl'
+  , Coercible typ typ'
+  ) => CoercibleRecordRL (Cons name typ trl) (Cons name typ' trl')
+else instance coercibleRecordRLConsOptional ::
+  ( CoercibleRecordRL trl trl'
+  , Coercible Undefined t
+  ) => CoercibleRecordRL trl (Cons name t trl')
+
+
+coerce :: forall a b. Coercible a b => a -> b
+coerce = unsafeCoerce

--- a/src/Runtime/OneOf.js
+++ b/src/Runtime/OneOf.js
@@ -1,0 +1,1 @@
+exports.undefined = undefined;

--- a/src/Runtime/OneOf.js
+++ b/src/Runtime/OneOf.js
@@ -1,1 +1,0 @@
-exports.undefined = undefined;

--- a/src/Runtime/OneOf.purs
+++ b/src/Runtime/OneOf.purs
@@ -20,6 +20,7 @@ import Prelude
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested (type (/\), (/\))
+import Foreign (unsafeToForeign)
 import Prim.RowList (class RowToList, Cons, Nil, kind RowList)
 import Runtime.TypeCheck (class HasRuntimeType, hasRuntimeType)
 import Runtime.Undefined (Undefined)
@@ -54,7 +55,7 @@ asOneOf = unsafeCoerce
 
 fromOneOf :: forall h t a. InOneOf a h t => HasRuntimeType a => OneOf h t -> Maybe a
 fromOneOf f =
-  if hasRuntimeType (Proxy :: Proxy a) f
+  if hasRuntimeType (Proxy :: Proxy a) (unsafeToForeign f)
   then Just $ unsafeCoerce f
   else Nothing
 
@@ -66,7 +67,7 @@ fromOneOf f =
 --| Example: toEither1 (asOneOf 3.0 :: Int |+| Number) == Left 3
 toEither1 :: forall a b. HasRuntimeType a => HasRuntimeType b => OneOf a b -> Either a b
 toEither1 o =
-  if isTypeA o
+  if isTypeA (unsafeToForeign o)
   then Left (unsafeCoerce o)
   else Right (unsafeCoerce o)
   where

--- a/src/Runtime/OneOf.purs
+++ b/src/Runtime/OneOf.purs
@@ -2,8 +2,6 @@ module Runtime.OneOf
        ( OneOf
        , type (|+|)
        , class InOneOf
-       , Undefined
-       , undefined
        , UndefinedOr
        , class HasUndefined
        , asOneOf
@@ -24,6 +22,7 @@ import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested (type (/\), (/\))
 import Prim.RowList (class RowToList, Cons, Nil, kind RowList)
 import Runtime.TypeCheck (class HasRuntimeType, hasRuntimeType)
+import Runtime.Undefined (Undefined)
 import Type.Proxy (Proxy(..))
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -44,9 +43,6 @@ class InOneOf a h t
 instance inOneOfHead :: InOneOf a a t
 else instance inOneOfLast :: InOneOf a h a
 else instance inOneOfTail :: (InOneOf a h' t') => InOneOf a h (OneOf h' t')
-
-foreign import data Undefined :: Type
-foreign import undefined :: Undefined
 
 type UndefinedOr a = OneOf a Undefined
 

--- a/src/Runtime/TypeCheck.js
+++ b/src/Runtime/TypeCheck.js
@@ -1,3 +1,9 @@
 exports.isInt = function (x) {
   return typeof(x) == "number" && ((x|0) === x);
 };
+
+exports.getProperty = function (name) {
+  return function (x) {
+    return x[name];
+  };
+};

--- a/src/Runtime/TypeCheck.js
+++ b/src/Runtime/TypeCheck.js
@@ -1,5 +1,3 @@
-exports.undefined = undefined;
-
 exports.jsTypeOf = function (x) {
   return typeof(x);
 };

--- a/src/Runtime/TypeCheck.js
+++ b/src/Runtime/TypeCheck.js
@@ -1,7 +1,3 @@
-exports.jsTypeOf = function (x) {
-  return typeof(x);
-};
-
 exports.isInt = function (x) {
   return typeof(x) == "number" && ((x|0) === x);
 };

--- a/src/Runtime/TypeCheck.purs
+++ b/src/Runtime/TypeCheck.purs
@@ -21,7 +21,7 @@ import Type.RowList (RLProxy(..))
 import Unsafe.Coerce (unsafeCoerce)
 
 class HasRuntimeType a where
-  hasRuntimeType :: forall x. Proxy a -> x -> Boolean
+  hasRuntimeType :: Proxy a -> Foreign -> Boolean
 
 instance hasRuntimeTypeBoolean :: HasRuntimeType Boolean where
   hasRuntimeType _ = hasJsType "boolean"
@@ -70,7 +70,7 @@ instance hasRuntimeTypeRecordRLCons ::
 
 foreign import getProperty :: String -> Foreign -> Foreign
 
-newtypeHasRuntimeType :: forall a r x. Newtype a r => HasRuntimeType r => Proxy a -> x -> Boolean
+newtypeHasRuntimeType :: forall a r. Newtype a r => HasRuntimeType r => Proxy a -> Foreign -> Boolean
 newtypeHasRuntimeType _ = hasRuntimeType (Proxy :: Proxy r)
 
 foreign import isInt :: forall x. x -> Boolean
@@ -81,7 +81,7 @@ hasJsType name x =
 
 cast :: forall a x. HasRuntimeType a => x -> Maybe a
 cast x =
-  if hasRuntimeTypeA x
+  if hasRuntimeTypeA (unsafeToForeign x)
   then Just (unsafeCoerce x)
   else Nothing
 

--- a/src/Runtime/TypeCheck.purs
+++ b/src/Runtime/TypeCheck.purs
@@ -3,14 +3,13 @@ module Runtime.TypeCheck
        , hasRuntimeType
        , newtypeHasRuntimeType
        , cast
-       , hasJsType
        ) where
 
 import Prelude
 
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
-import Foreign (Foreign)
+import Foreign (Foreign, typeOf)
 import Foreign.Object (Object)
 import Foreign.Object as Object
 import Type.Proxy (Proxy(..))
@@ -44,11 +43,10 @@ newtypeHasRuntimeType :: forall a r x. Newtype a r => HasRuntimeType r => Proxy 
 newtypeHasRuntimeType _ = hasRuntimeType (Proxy :: Proxy r)
 
 foreign import isInt :: forall x. x -> Boolean
-foreign import jsTypeOf :: forall x. x -> String
 
 hasJsType :: forall x. String -> x -> Boolean
 hasJsType name x =
-  jsTypeOf x == name
+  typeOf (unsafeCoerce x) == name
 
 cast :: forall a x. HasRuntimeType a => x -> Maybe a
 cast x =

--- a/src/Runtime/TypeCheck.purs
+++ b/src/Runtime/TypeCheck.purs
@@ -16,12 +16,16 @@ import Foreign (Foreign, typeOf, unsafeToForeign)
 import Foreign.Object (Object)
 import Foreign.Object as Object
 import Prim.RowList (class RowToList, Cons, Nil, kind RowList)
+import Runtime.Undefined (Undefined)
 import Type.Proxy (Proxy(..))
 import Type.RowList (RLProxy(..))
 import Unsafe.Coerce (unsafeCoerce)
 
 class HasRuntimeType a where
   hasRuntimeType :: Proxy a -> Foreign -> Boolean
+
+instance hasRuntimeTypeUndefined :: HasRuntimeType Undefined where
+  hasRuntimeType _ = hasJsType "undefined"
 
 instance hasRuntimeTypeBoolean :: HasRuntimeType Boolean where
   hasRuntimeType _ = hasJsType "boolean"

--- a/src/Runtime/TypeCheck.purs
+++ b/src/Runtime/TypeCheck.purs
@@ -1,0 +1,49 @@
+module Runtime.TypeCheck
+       ( class HasRuntimeType
+       , hasRuntimeType
+       , newtypeHasRuntimeType
+       , cast
+       , jsTypeOf
+       , hasJsType
+       ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Type.Proxy (Proxy(..))
+import Unsafe.Coerce (unsafeCoerce)
+
+class HasRuntimeType a where
+  hasRuntimeType :: forall x. Proxy a -> x -> Boolean
+
+instance hasRuntimeTypeBoolean :: HasRuntimeType Boolean where
+  hasRuntimeType _ = hasJsType "boolean"
+
+instance hasRuntimeTypeInt :: HasRuntimeType Int where
+  hasRuntimeType _ = isInt
+
+instance hasRuntimeTypeNumber :: HasRuntimeType Number where
+  hasRuntimeType _ = hasJsType "number"
+
+instance hasRuntimeTypeString :: HasRuntimeType String where
+  hasRuntimeType _ = hasJsType "string"
+
+newtypeHasRuntimeType :: forall a r x. Newtype a r => HasRuntimeType r => Proxy a -> x -> Boolean
+newtypeHasRuntimeType _ = hasRuntimeType (Proxy :: Proxy r)
+
+foreign import jsTypeOf :: forall x. x -> String
+foreign import isInt :: forall x. x -> Boolean
+
+hasJsType :: forall x. String -> x -> Boolean
+hasJsType name x =
+  jsTypeOf x == name
+
+cast :: forall a x. HasRuntimeType a => x -> Maybe a
+cast x =
+  if hasRuntimeTypeA x
+  then Just (unsafeCoerce x)
+  else Nothing
+
+  where
+    hasRuntimeTypeA = hasRuntimeType (Proxy :: Proxy a)

--- a/src/Runtime/Undefined.js
+++ b/src/Runtime/Undefined.js
@@ -1,0 +1,1 @@
+exports.undefined = undefined;

--- a/src/Runtime/Undefined.purs
+++ b/src/Runtime/Undefined.purs
@@ -1,0 +1,13 @@
+module Runtime.Undefined
+       ( Undefined
+       , undefined
+       ) where
+
+import Prelude
+
+foreign import data Undefined :: Type
+
+instance undefinedEq :: Eq Undefined where
+  eq _ _ = true
+
+foreign import undefined :: Undefined

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,127 +1,14 @@
-module Test.Main where
+module Test.Main
+       ( main
+       ) where
 
 import Prelude
 
-import Data.Either (Either(..), isLeft)
-import Data.Maybe (Maybe(..))
-import Data.Tuple.Nested ((/\))
 import Effect (Effect)
-import Effect.Console (log)
-import OneOf (type (|+|), Undefined, asOneOf, fromOneOf, toEither1, reduce, undefined, urecord)
-import Test.Assert (assertEqual, assertTrue)
-
-type ISB = Int |+| String |+| Boolean
-
-type Props =
-  { str :: String
-  , isb :: ISB
-  , numOrUndef :: Number |+| Undefined
-  , strOrNumOrUndef :: String |+| Number |+| Undefined
-  }
+import Runtime.OneOfTest (testOneOf)
+import Runtime.TypeCheckTest (testTypeCheck)
 
 main :: Effect Unit
 main = do
-  -- asOneOf compile tests
-  let isbInt = asOneOf 20 :: ISB
-  let isbString = asOneOf "foo" :: ISB
-
-  -- should not compile
-  --let isbNumber = asOneOf 3.5 :: ISB
-
-  assertEqual
-    { actual: fromOneOf isbInt
-    , expected: Just 20
-    }
-
-  assertEqual
-    { actual: fromOneOf isbInt
-    , expected: (Nothing :: Maybe String)
-    }
-
-  assertEqual
-    { actual: fromOneOf isbString
-    , expected: Just "foo"
-    }
-
-  assertEqual
-    { actual: fromOneOf isbString
-    , expected: (Nothing :: Maybe Int)
-    }
-
-  -- Eq instance
-  assertTrue (isbInt == isbInt)
-  assertTrue (isbInt /= asOneOf 100)
-  assertTrue (isbString /= asOneOf 100)
-
-  -- toEither1
-  assertTrue (toEither1 isbInt == (Left 20 :: Either Int (String |+| Boolean)))
-  assertTrue (toEither1 isbString == (Right (asOneOf "foo")))
-
-  -- left bias:
-  assertTrue (isLeft $ toEither1 (asOneOf 3 :: Int |+| Int))
-  assertTrue (isLeft $ toEither1 (asOneOf 3.0 :: Int |+| Number))
-
-  -- reduce
-  let
-    reduceISB =
-        reduce ( (\(i :: Int) -> "i" <> show i)
-                 /\ (\(s :: String) -> "s" <> s)
-                 /\ (\(b :: Boolean) -> "b" <> show b)
-               )
-  assertEqual
-    { actual: reduceISB isbInt
-    , expected: "i20"
-    }
-  assertEqual
-    { actual: reduceISB isbString
-    , expected: "sfoo"
-    }
-
-  -- urecord compile tests
-  let pExplicitOneOf =
-        urecord { str: "foo"
-                , isb: (asOneOf 3 :: ISB)
-                , numOrUndef: (asOneOf 2.0 :: Number |+| Undefined)
-                , strOrNumOrUndef: (asOneOf "bar" :: String |+| Number |+| Undefined)
-                } :: Props
-
-  let pNoExplicitOneOf =
-        urecord { str: "foo"
-                , isb: "bar"
-                , numOrUndef: undefined
-                , strOrNumOrUndef: 3.0
-                } :: Props
-
-  let pMixExplicitOneOf =
-        urecord { str: "foo"
-                , isb: "bar"
-                , numOrUndef: undefined
-                , strOrNumOrUndef: (asOneOf "bar" :: String |+| Number |+| Undefined)
-                } :: Props
-
-  let pOmitOptional =
-        urecord { str: "foo"
-                , isb: "bar"
-                } :: Props
-
-
-  -- should not compile
---  let pMissingStr =
---       urecord { isb: "bar"
---               , numOrUndef: undefined
---               , strOrNumOrUndef: 3.0
---               } :: Props
-
---  let pMissingIsb =
---        urecord { str: "foo"
---                , numOrUndef: undefined
---                , strOrNumOrUndef: 3.0
---                } :: Props
-
---  let pWrongNumOrUndef =
---        urecord { str: "foo"
---                , numOrUndef: "bar"
---                , strOrNumOrUndef: 3.0
---                } :: Props
-
-  log "done"
+  testTypeCheck
+  testOneOf

--- a/test/Runtime/CoercibleTest.purs
+++ b/test/Runtime/CoercibleTest.purs
@@ -1,0 +1,71 @@
+module Runtime.CoercibleTest
+       ( testCoerce
+       ) where
+
+import Prelude
+
+import Effect (Effect)
+import Runtime.Coercible (coerce)
+import Runtime.OneOf (type (|+|))
+import Runtime.Undefined (Undefined, undefined)
+
+type Props =
+  { str :: String
+  , isb :: Int |+| String |+| Boolean
+  , numOrUndef :: Number |+| Undefined
+  , strOrNumOrUndef :: String |+| Number |+| Undefined
+  }
+
+
+testCoerce :: Effect Unit
+testCoerce = do
+
+  -- urecord compile tests
+  let pExplicitOneOf =
+        coerce { str: "foo"
+               , isb: (coerce 3 :: Int |+| String |+| Boolean)
+               , numOrUndef: (coerce 2.0 :: Number |+| Undefined)
+               , strOrNumOrUndef: (coerce "bar" :: String |+| Number |+| Undefined)
+               } :: Props
+
+  let pNoExplicitOneOf =
+        coerce { str: "foo"
+               , isb: "bar"
+               , numOrUndef: undefined
+               , strOrNumOrUndef: 3.0
+               } :: Props
+
+  let pMixExplicitOneOf =
+        coerce { str: "foo"
+               , isb: "bar"
+               , numOrUndef: undefined
+               , strOrNumOrUndef: (coerce "bar" :: String |+| Number |+| Undefined)
+               } :: Props
+
+  let pOmitOptional =
+        coerce { str: "foo"
+               , isb: "bar"
+               } :: Props
+
+
+  -- should not compile
+--  let pMissingStr =
+--       coerce { isb: "bar"
+--              , numOrUndef: undefined
+--              , strOrNumOrUndef: 3.0
+--              } :: Props
+
+--  let pMissingIsb =
+--        coerce { str: "foo"
+--               , numOrUndef: undefined
+--               , strOrNumOrUndef: 3.0
+--               } :: Props
+
+--  let pWrongNumOrUndef =
+--        coerce { str: "foo"
+--               , numOrUndef: "bar"
+--               , strOrNumOrUndef: 3.0
+--               } :: Props
+
+
+  pure unit

--- a/test/Runtime/OneOfTest.purs
+++ b/test/Runtime/OneOfTest.purs
@@ -9,7 +9,8 @@ import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\))
 import Effect (Effect)
 import Effect.Console (log)
-import Runtime.OneOf (type (|+|), Undefined, asOneOf, fromOneOf, toEither1, reduce, undefined, urecord)
+import Runtime.OneOf (type (|+|), asOneOf, fromOneOf, toEither1, reduce, urecord)
+import Runtime.Undefined (Undefined, undefined)
 import Test.Assert (assertEqual, assertTrue)
 
 type ISB = Int |+| String |+| Boolean

--- a/test/Runtime/OneOfTest.purs
+++ b/test/Runtime/OneOfTest.purs
@@ -9,8 +9,8 @@ import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\))
 import Effect (Effect)
 import Effect.Console (log)
-import Runtime.OneOf (type (|+|), asOneOf, fromOneOf, toEither1, reduce, urecord)
-import Runtime.Undefined (Undefined, undefined)
+import Runtime.OneOf (type (|+|), asOneOf, fromOneOf, reduce, toEither1)
+import Runtime.Undefined (Undefined)
 import Test.Assert (assertEqual, assertTrue)
 
 type ISB = Int |+| String |+| Boolean
@@ -79,52 +79,5 @@ testOneOf = do
     { actual: reduceISB isbString
     , expected: "sfoo"
     }
-
-  -- urecord compile tests
-  let pExplicitOneOf =
-        urecord { str: "foo"
-                , isb: (asOneOf 3 :: ISB)
-                , numOrUndef: (asOneOf 2.0 :: Number |+| Undefined)
-                , strOrNumOrUndef: (asOneOf "bar" :: String |+| Number |+| Undefined)
-                } :: Props
-
-  let pNoExplicitOneOf =
-        urecord { str: "foo"
-                , isb: "bar"
-                , numOrUndef: undefined
-                , strOrNumOrUndef: 3.0
-                } :: Props
-
-  let pMixExplicitOneOf =
-        urecord { str: "foo"
-                , isb: "bar"
-                , numOrUndef: undefined
-                , strOrNumOrUndef: (asOneOf "bar" :: String |+| Number |+| Undefined)
-                } :: Props
-
-  let pOmitOptional =
-        urecord { str: "foo"
-                , isb: "bar"
-                } :: Props
-
-
-  -- should not compile
---  let pMissingStr =
---       urecord { isb: "bar"
---               , numOrUndef: undefined
---               , strOrNumOrUndef: 3.0
---               } :: Props
-
---  let pMissingIsb =
---        urecord { str: "foo"
---                , numOrUndef: undefined
---                , strOrNumOrUndef: 3.0
---                } :: Props
-
---  let pWrongNumOrUndef =
---        urecord { str: "foo"
---                , numOrUndef: "bar"
---                , strOrNumOrUndef: 3.0
---                } :: Props
 
   log "done"

--- a/test/Runtime/OneOfTest.purs
+++ b/test/Runtime/OneOfTest.purs
@@ -1,0 +1,129 @@
+module Runtime.OneOfTest
+       ( testOneOf
+       ) where
+
+import Prelude
+
+import Data.Either (Either(..), isLeft)
+import Data.Maybe (Maybe(..))
+import Data.Tuple.Nested ((/\))
+import Effect (Effect)
+import Effect.Console (log)
+import Runtime.OneOf (type (|+|), Undefined, asOneOf, fromOneOf, toEither1, reduce, undefined, urecord)
+import Test.Assert (assertEqual, assertTrue)
+
+type ISB = Int |+| String |+| Boolean
+
+type Props =
+  { str :: String
+  , isb :: ISB
+  , numOrUndef :: Number |+| Undefined
+  , strOrNumOrUndef :: String |+| Number |+| Undefined
+  }
+
+testOneOf :: Effect Unit
+testOneOf = do
+  -- asOneOf compile tests
+  let isbInt = asOneOf 20 :: ISB
+  let isbString = asOneOf "foo" :: ISB
+
+  -- should not compile
+  --let isbNumber = asOneOf 3.5 :: ISB
+
+  assertEqual
+    { actual: fromOneOf isbInt
+    , expected: Just 20
+    }
+
+  assertEqual
+    { actual: fromOneOf isbInt
+    , expected: (Nothing :: Maybe String)
+    }
+
+  assertEqual
+    { actual: fromOneOf isbString
+    , expected: Just "foo"
+    }
+
+  assertEqual
+    { actual: fromOneOf isbString
+    , expected: (Nothing :: Maybe Int)
+    }
+
+  -- Eq instance
+  assertTrue (isbInt == isbInt)
+  assertTrue (isbInt /= asOneOf 100)
+  assertTrue (isbString /= asOneOf 100)
+
+  -- toEither1
+  assertTrue (toEither1 isbInt == (Left 20 :: Either Int (String |+| Boolean)))
+  assertTrue (toEither1 isbString == (Right (asOneOf "foo")))
+
+  -- left bias:
+  assertTrue (isLeft $ toEither1 (asOneOf 3 :: Int |+| Int))
+  assertTrue (isLeft $ toEither1 (asOneOf 3.0 :: Int |+| Number))
+
+  -- reduce
+  let
+    reduceISB =
+        reduce ( (\(i :: Int) -> "i" <> show i)
+                 /\ (\(s :: String) -> "s" <> s)
+                 /\ (\(b :: Boolean) -> "b" <> show b)
+               )
+  assertEqual
+    { actual: reduceISB isbInt
+    , expected: "i20"
+    }
+  assertEqual
+    { actual: reduceISB isbString
+    , expected: "sfoo"
+    }
+
+  -- urecord compile tests
+  let pExplicitOneOf =
+        urecord { str: "foo"
+                , isb: (asOneOf 3 :: ISB)
+                , numOrUndef: (asOneOf 2.0 :: Number |+| Undefined)
+                , strOrNumOrUndef: (asOneOf "bar" :: String |+| Number |+| Undefined)
+                } :: Props
+
+  let pNoExplicitOneOf =
+        urecord { str: "foo"
+                , isb: "bar"
+                , numOrUndef: undefined
+                , strOrNumOrUndef: 3.0
+                } :: Props
+
+  let pMixExplicitOneOf =
+        urecord { str: "foo"
+                , isb: "bar"
+                , numOrUndef: undefined
+                , strOrNumOrUndef: (asOneOf "bar" :: String |+| Number |+| Undefined)
+                } :: Props
+
+  let pOmitOptional =
+        urecord { str: "foo"
+                , isb: "bar"
+                } :: Props
+
+
+  -- should not compile
+--  let pMissingStr =
+--       urecord { isb: "bar"
+--               , numOrUndef: undefined
+--               , strOrNumOrUndef: 3.0
+--               } :: Props
+
+--  let pMissingIsb =
+--        urecord { str: "foo"
+--                , numOrUndef: undefined
+--                , strOrNumOrUndef: 3.0
+--                } :: Props
+
+--  let pWrongNumOrUndef =
+--        urecord { str: "foo"
+--                , numOrUndef: "bar"
+--                , strOrNumOrUndef: 3.0
+--                } :: Props
+
+  log "done"

--- a/test/Runtime/TypeCheckTest.js
+++ b/test/Runtime/TypeCheckTest.js
@@ -1,0 +1,2 @@
+var o = { i: 1 };
+exports.sampleWithInherited = Object.create(o);

--- a/test/Runtime/TypeCheckTest.purs
+++ b/test/Runtime/TypeCheckTest.purs
@@ -7,7 +7,7 @@ import Prelude
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 import Effect (Effect)
-import Foreign (Foreign)
+import Foreign (Foreign, unsafeToForeign)
 import Foreign.Object as Foreign
 import Runtime.TypeCheck (class HasRuntimeType, cast, hasRuntimeType, newtypeHasRuntimeType)
 import Test.Assert (assertEqual, assertFalse, assertTrue)
@@ -20,37 +20,40 @@ instance myStringHasRuntimeType :: HasRuntimeType MyString where
 
 testTypeCheck :: Effect Unit
 testTypeCheck = do
-  assertTrue (hasRuntimeType (Proxy :: _ Boolean) true)
-  assertTrue (hasRuntimeType (Proxy :: _ Boolean) false)
-  assertFalse (hasRuntimeType (Proxy :: _ Boolean) 0)
+  assertTrue (hasRuntimeTypeF (Proxy :: _ Boolean) true)
+  assertTrue (hasRuntimeTypeF (Proxy :: _ Boolean) false)
+  assertFalse (hasRuntimeTypeF (Proxy :: _ Boolean) 0)
 
-  assertTrue (hasRuntimeType (Proxy :: _ Int) 2)
-  assertTrue (hasRuntimeType (Proxy :: _ Int) 2.0)
-  assertFalse (hasRuntimeType (Proxy :: _ Int) "foo")
+  assertTrue (hasRuntimeTypeF (Proxy :: _ Int) 2)
+  assertTrue (hasRuntimeTypeF (Proxy :: _ Int) 2.0)
+  assertFalse (hasRuntimeTypeF (Proxy :: _ Int) "foo")
 
-  assertTrue (hasRuntimeType (Proxy :: _ Number) 2.2)
-  assertFalse (hasRuntimeType (Proxy :: _ Number) "foo")
+  assertTrue (hasRuntimeTypeF (Proxy :: _ Number) 2.2)
+  assertFalse (hasRuntimeTypeF (Proxy :: _ Number) "foo")
 
-  assertTrue (hasRuntimeType (Proxy :: _ String) "foo")
-  assertFalse (hasRuntimeType (Proxy :: _ String) 2.0)
+  assertTrue (hasRuntimeTypeF (Proxy :: _ String) "foo")
+  assertFalse (hasRuntimeTypeF (Proxy :: _ String) 2.0)
 
-  assertTrue (hasRuntimeType (Proxy :: _ Foreign) "foo")
+  assertTrue (hasRuntimeTypeF (Proxy :: _ Foreign) "foo")
 
-  assertTrue (hasRuntimeType (Proxy :: _ (Foreign.Object Foreign)) {i: 2})
-  assertFalse (hasRuntimeType (Proxy :: _ (Foreign.Object Foreign)) 2)
-  assertFalse (hasRuntimeType (Proxy :: _ (Foreign.Object String)) {i: 2})
+  assertTrue (hasRuntimeTypeF (Proxy :: _ (Foreign.Object Foreign)) {i: 2})
+  assertFalse (hasRuntimeTypeF (Proxy :: _ (Foreign.Object Foreign)) 2)
+  assertFalse (hasRuntimeTypeF (Proxy :: _ (Foreign.Object String)) {i: 2})
 
-  assertTrue (hasRuntimeType (Proxy :: _ {i :: Int, s :: MyString}) {i: 2.0, s: "foo"})
-  assertTrue (hasRuntimeType (Proxy :: _ {i :: Int}) sampleWithInherited)
-  assertFalse (hasRuntimeType (Proxy :: _ {i :: Int}) 5)
+  assertTrue (hasRuntimeTypeF (Proxy :: _ {i :: Int, s :: MyString}) {i: 2.0, s: "foo"})
+  assertTrue (hasRuntimeTypeF (Proxy :: _ {i :: Int}) sampleWithInherited)
+  assertFalse (hasRuntimeTypeF (Proxy :: _ {i :: Int}) 5)
   -- should allow for extra members
-  assertTrue (hasRuntimeType (Proxy :: _ {i :: Int}) {i: 2.0, s: "foo"})
+  assertTrue (hasRuntimeTypeF (Proxy :: _ {i :: Int}) {i: 2.0, s: "foo"})
 
   -- Newtypes
-  assertTrue (hasRuntimeType (Proxy :: _ MyString) "foo")
+  assertTrue (hasRuntimeTypeF (Proxy :: _ MyString) "foo")
 
   -- Cast
   assertEqual { actual: cast 2.0, expected: Just 2 }
   assertEqual { actual: cast "foo", expected: (Nothing :: Maybe Int) }
 
 foreign import sampleWithInherited :: Foreign
+
+hasRuntimeTypeF :: forall a x. HasRuntimeType a => Proxy a -> x -> Boolean
+hasRuntimeTypeF p x = hasRuntimeType p (unsafeToForeign x)

--- a/test/Runtime/TypeCheckTest.purs
+++ b/test/Runtime/TypeCheckTest.purs
@@ -1,0 +1,40 @@
+module Runtime.TypeCheckTest
+       ( testTypeCheck
+       ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Effect (Effect)
+import Runtime.TypeCheck (class HasRuntimeType, cast, hasRuntimeType, newtypeHasRuntimeType)
+import Test.Assert (assertEqual, assertFalse, assertTrue)
+import Type.Proxy (Proxy(..))
+
+newtype MyString = MyString String
+derive instance myStringNewtype :: Newtype MyString _
+instance myStringHasRuntimeType :: HasRuntimeType MyString where
+  hasRuntimeType = newtypeHasRuntimeType
+
+testTypeCheck :: Effect Unit
+testTypeCheck = do
+  assertTrue (hasRuntimeType (Proxy :: _ Boolean) true)
+  assertTrue (hasRuntimeType (Proxy :: _ Boolean) false)
+  assertFalse (hasRuntimeType (Proxy :: _ Boolean) 0)
+
+  assertTrue (hasRuntimeType (Proxy :: _ Int) 2)
+  assertTrue (hasRuntimeType (Proxy :: _ Int) 2.0)
+  assertFalse (hasRuntimeType (Proxy :: _ Int) "foo")
+
+  assertTrue (hasRuntimeType (Proxy :: _ Number) 2.2)
+  assertFalse (hasRuntimeType (Proxy :: _ Number) "foo")
+
+  assertTrue (hasRuntimeType (Proxy :: _ String) "foo")
+  assertFalse (hasRuntimeType (Proxy :: _ String) 2.0)
+
+  -- Newtypes
+  assertTrue (hasRuntimeType (Proxy :: _ MyString) "foo")
+
+  -- Cast
+  assertEqual { actual: cast 2.0, expected: Just 2 }
+  assertEqual { actual: cast "foo", expected: (Nothing :: Maybe Int) }

--- a/test/Runtime/TypeCheckTest.purs
+++ b/test/Runtime/TypeCheckTest.purs
@@ -36,9 +36,15 @@ testTypeCheck = do
 
   assertTrue (hasRuntimeType (Proxy :: _ Foreign) "foo")
 
-  assertFalse (hasRuntimeType (Proxy :: _ (Foreign.Object Foreign)) 2)
   assertTrue (hasRuntimeType (Proxy :: _ (Foreign.Object Foreign)) {i: 2})
+  assertFalse (hasRuntimeType (Proxy :: _ (Foreign.Object Foreign)) 2)
   assertFalse (hasRuntimeType (Proxy :: _ (Foreign.Object String)) {i: 2})
+
+  assertTrue (hasRuntimeType (Proxy :: _ {i :: Int, s :: MyString}) {i: 2.0, s: "foo"})
+  assertTrue (hasRuntimeType (Proxy :: _ {i :: Int}) sampleWithInherited)
+  assertFalse (hasRuntimeType (Proxy :: _ {i :: Int}) 5)
+  -- should allow for extra members
+  assertTrue (hasRuntimeType (Proxy :: _ {i :: Int}) {i: 2.0, s: "foo"})
 
   -- Newtypes
   assertTrue (hasRuntimeType (Proxy :: _ MyString) "foo")
@@ -46,3 +52,5 @@ testTypeCheck = do
   -- Cast
   assertEqual { actual: cast 2.0, expected: Just 2 }
   assertEqual { actual: cast "foo", expected: (Nothing :: Maybe Int) }
+
+foreign import sampleWithInherited :: Foreign

--- a/test/Runtime/TypeCheckTest.purs
+++ b/test/Runtime/TypeCheckTest.purs
@@ -10,6 +10,7 @@ import Effect (Effect)
 import Foreign (Foreign, unsafeToForeign)
 import Foreign.Object as Foreign
 import Runtime.TypeCheck (class HasRuntimeType, cast, hasRuntimeType, newtypeHasRuntimeType)
+import Runtime.Undefined (Undefined, undefined)
 import Test.Assert (assertEqual, assertFalse, assertTrue)
 import Type.Proxy (Proxy(..))
 
@@ -20,6 +21,9 @@ instance myStringHasRuntimeType :: HasRuntimeType MyString where
 
 testTypeCheck :: Effect Unit
 testTypeCheck = do
+  assertTrue (hasRuntimeTypeF (Proxy :: _ Undefined) undefined)
+  assertFalse (hasRuntimeTypeF (Proxy :: _ Undefined) true)
+
   assertTrue (hasRuntimeTypeF (Proxy :: _ Boolean) true)
   assertTrue (hasRuntimeTypeF (Proxy :: _ Boolean) false)
   assertFalse (hasRuntimeTypeF (Proxy :: _ Boolean) 0)

--- a/test/Runtime/TypeCheckTest.purs
+++ b/test/Runtime/TypeCheckTest.purs
@@ -7,6 +7,8 @@ import Prelude
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 import Effect (Effect)
+import Foreign (Foreign)
+import Foreign.Object as Foreign
 import Runtime.TypeCheck (class HasRuntimeType, cast, hasRuntimeType, newtypeHasRuntimeType)
 import Test.Assert (assertEqual, assertFalse, assertTrue)
 import Type.Proxy (Proxy(..))
@@ -31,6 +33,12 @@ testTypeCheck = do
 
   assertTrue (hasRuntimeType (Proxy :: _ String) "foo")
   assertFalse (hasRuntimeType (Proxy :: _ String) 2.0)
+
+  assertTrue (hasRuntimeType (Proxy :: _ Foreign) "foo")
+
+  assertFalse (hasRuntimeType (Proxy :: _ (Foreign.Object Foreign)) 2)
+  assertTrue (hasRuntimeType (Proxy :: _ (Foreign.Object Foreign)) {i: 2})
+  assertFalse (hasRuntimeType (Proxy :: _ (Foreign.Object String)) {i: 2})
 
   -- Newtypes
   assertTrue (hasRuntimeType (Proxy :: _ MyString) "foo")

--- a/test/Sample.purs
+++ b/test/Sample.purs
@@ -1,6 +1,6 @@
 module Test.Sample where
 
-import OneOf (type (|+|), Undefined, UndefinedOr, asOneOf, fromOneOf, urecord)
+import Runtime.OneOf (type (|+|), Undefined, UndefinedOr, asOneOf, fromOneOf, urecord)
 import Data.Maybe (Maybe)
 
 type ISB = Int |+| String |+| Boolean

--- a/test/Sample.purs
+++ b/test/Sample.purs
@@ -1,6 +1,7 @@
 module Test.Sample where
 
-import Runtime.OneOf (type (|+|), Undefined, UndefinedOr, asOneOf, fromOneOf, urecord)
+import Runtime.OneOf (type (|+|), UndefinedOr, asOneOf, fromOneOf, urecord)
+import Runtime.Undefined (Undefined)
 import Data.Maybe (Maybe)
 
 type ISB = Int |+| String |+| Boolean

--- a/test/Sample.purs
+++ b/test/Sample.purs
@@ -1,8 +1,9 @@
 module Test.Sample where
 
-import Runtime.OneOf (type (|+|), UndefinedOr, asOneOf, fromOneOf, urecord)
-import Runtime.Undefined (Undefined)
 import Data.Maybe (Maybe)
+import Runtime.Coercible (coerce)
+import Runtime.OneOf (type (|+|), UndefinedOr, asOneOf, fromOneOf)
+import Runtime.Undefined (Undefined)
 
 type ISB = Int |+| String |+| Boolean
 
@@ -38,10 +39,10 @@ type Props =
 
 sampleProps :: Props
 sampleProps =
-  urecord { text: "foo" -- text is required and should be a string
+  coerce { text: "foo" -- text is required and should be a string
 
-          , width: 30.0 -- width is optional, and may be defined, but should be a Number
-          -- height is optional and may be omitted
+         , width: 30.0 -- width is optional, and may be defined, but should be a Number
+           -- height is optional and may be omitted
 
-          , fontSize: "100%" -- fontSize may be defined, and should either be a string or number
-          }
+         , fontSize: "100%" -- fontSize may be defined, and should either be a string or number
+         }


### PR DESCRIPTION
Did some reorganizing, and here's a draft. Some notable changes:

## Create `Runtime.TypeCheck`

This includes the typeclass `HasRuntimeType` formerly named as `RawType`.

An instance `HasRuntimeType a` simply has a function called `hasRuntimeType` that takes in some `Foreign` and returns true of the `Foreign` can be coerced to an `a`.

## Generalize `Runtime.Coercible`

An instance `Coercible a b` indicates that all values of type `a` can be safely coerced to `b`. This actually generalizes creation of the untagged unions, coercing of records, etc.

## Move `OneOf` to `Runtime.OneOf` 

I'm still keen to renaming this to _untagged union_. But moving it under `Runtime` so everything goes there for now.

----

Assuming we move `Undefined` to `literals`, the dependency tree can look like:

```
        Literals
           |
    .------'------.
   |              |
TypeCheck      Coercible
   |              |
   '------.------'
          |
     UntaggedUnion
```

I also probably wouldn't retain the `Runtime` prefix for long though.

One option then is to spin off `TypeCheck` and `Coercible` into their own packages. Looks like they're useful outside of the untagged union use case.

The other option is just to keep them all in this repo and pick a better name (and module prefix).

Thoughts @paluh?